### PR TITLE
ARC64: libffi: Use specific version of libffi

### DIFF
--- a/package/libffi/73acfaf8cfd445e9d44b40de8a07d06d8be71e1f/0001-Fix-installation-location-of-libffi.patch
+++ b/package/libffi/73acfaf8cfd445e9d44b40de8a07d06d8be71e1f/0001-Fix-installation-location-of-libffi.patch
@@ -1,0 +1,55 @@
+From 580f46a7bc6e9fea3a2227b5268cc3aed1d60e3b Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+Date: Thu, 7 Feb 2013 22:26:56 +0100
+Subject: [PATCH] Fix installation location of libffi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The libffi is currently declared as toolexeclib_LTLIBRARIES. In many
+cases, toolexeclib libraries will be installed in /usr/lib, so it
+doesn't make any difference.
+
+However, with multilib toolchains, they get installed in a
+subdirectory of /usr/lib/. For example, with a Sourcery CodeBench
+PowerPC toolchain, if the e500mc multilib variant is used, the libffi
+library gets installed in /usr/lib/te500mc/. This is due to the
+following code in the configure script:
+
+  multi_os_directory=`$CC -print-multi-os-directory`
+  case $multi_os_directory in
+    .) ;; # Avoid trailing /.
+    *) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+  esac
+
+Once the library is installed in /usr/lib/te500mc/, nothing works
+because this installation location is inconsistent with the
+installation location declared in libffi.pc.
+
+So, instead of using this bizarre toolexeclib_LTLIBRARIES, simply use
+the more standard lib_LTLIBRARIES, which ensures that the libffi
+library is always installed in /usr/lib.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+[unfuzz for 3.2.1]
+Signed-off-by: Jörg Krause <joerg.krause@embedded.rocks>
+---
+ Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 0e40451..309474c 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -104,7 +104,7 @@ FLAGS_TO_PASS = $(AM_MAKEFLAGS)
+ 
+ MAKEOVERRIDES=
+ 
+-toolexeclib_LTLIBRARIES = libffi.la
++lib_LTLIBRARIES = libffi.la
+ noinst_LTLIBRARIES = libffi_convenience.la
+ 
+ libffi_la_SOURCES = src/prep_cif.c src/types.c \
+-- 
+2.5.3
+

--- a/package/libffi/libffi.hash
+++ b/package/libffi/libffi.hash
@@ -2,3 +2,5 @@
 sha256	3f2f86094f5cf4c36cfe850d2fe029d01f5c2c2296619407c8ba0d8207da9a6b  libffi-3.3.tar.gz
 # License files, locally calculated
 sha256	deaf3a42effb551a5b140fa9afefed183a27f1341c6d1bf430d106a5e6931fc0  LICENSE
+# Version of libffi with ARC64 support
+sha256	524d90dc2de0acdc0daa27a4e568c93c9918f842d44615cbf748155b2b2c6660  libffi-73acfaf8cfd445e9d44b40de8a07d06d8be71e1f.tar.gz

--- a/package/libffi/libffi.mk
+++ b/package/libffi/libffi.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-LIBFFI_VERSION = 3.3
-LIBFFI_SITE = $(call github,libffi,libffi,v$(LIBFFI_VERSION))
+LIBFFI_VERSION = 73acfaf8cfd445e9d44b40de8a07d06d8be71e1f
+LIBFFI_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,libffi,$(LIBFFI_VERSION))
 LIBFFI_LICENSE = MIT
 LIBFFI_LICENSE_FILES = LICENSE
 LIBFFI_INSTALL_STAGING = YES


### PR DESCRIPTION
With this commit we now able to build libffi and related packages, such as python.