### PR TITLE
ARC: libffi: Fix make legal-info

### DIFF
--- a/package/libffi/libffi.hash
+++ b/package/libffi/libffi.hash
@@ -1,4 +1,4 @@
 # Locally calculated
 sha256	3f2f86094f5cf4c36cfe850d2fe029d01f5c2c2296619407c8ba0d8207da9a6b  libffi-3.3.tar.gz
 # License files, locally calculated
-sha256	deaf3a42effb551a5b140fa9afefed183a27f1341c6d1bf430d106a5e6931fc0  LICENSE
+sha256	25d56871423a870487edee68000ef66b1a7ec44a7ab84838ceeb3ce07f734b74  LICENSE

--- a/package/libffi/libffi.mk
+++ b/package/libffi/libffi.mk
@@ -6,10 +6,8 @@
 
 LIBFFI_VERSION = arc64
 LIBFFI_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,libffi,$(LIBFFI_VERSION))
-ifeq ($(BR2_arc),y)
 LIBFFI_SOURCE = libffi-$(LIBFFI_VERSION).tar.gz
 BR_NO_CHECK_HASH_FOR += $(LIBFFI_SOURCE)
-endif
 LIBFFI_LICENSE = MIT
 LIBFFI_LICENSE_FILES = LICENSE
 LIBFFI_INSTALL_STAGING = YES


### PR DESCRIPTION
LICENSE checksum has changed because we are using fresh version
of libffi, so it has 2020 instead of 2019.

Signed-off-by: Vladimir Isaev <isaev@synopsys.com>