### PR TITLE
utils/genrandconfig: swith python to python3

### DIFF
--- a/utils/genrandconfig
+++ b/utils/genrandconfig
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright (C) 2014 by Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
 #


### PR DESCRIPTION
This script is being called from buildroot-test building instance which is currently running on CentOS 8. On CentOS 8 there is no 'python', only 'python3'.

At the moment this problem is being solved via creating a soft link from 'python' to 'python3':
```
mkdir ~/.local/bin
ln -s /usr/bin/python3 ~/.local/bin/python
export PATH=~/.local/bin:$PATH
```

If we change 'python' to 'python3' everywhere buildroot-test needs we won't need soft link parkour skills.

I already made similar change in buildroot-test [repository](https://gitsnps.internal.synopsys.com/kremneva/buildroot-test/-/commit/456d8f9213557b958d800c03a39b8632a586014e) that we are using.