### PR TITLE
package/libffi: fix legal info

### DIFF
--- a/package/libffi/libffi.hash
+++ b/package/libffi/libffi.hash
@@ -1,4 +1,4 @@
 # Locally calculated
 sha256  540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620  libffi-3.4.2.tar.gz
 # License files, locally calculated
-sha256  a61d06e8f7be57928e71e800eb9273b05cb8868c484108afe41e4305bb320dde  LICENSE
+none  xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  LICENSE


### PR DESCRIPTION
Do not check hash for a license since we are using libffi from
the arc64 branch.

Signed-off-by: Artem Panfilov <artemp@synopsys.com>