### PR TITLE
package/libnspr: Add ARC64 support

### DIFF
--- a/package/libnspr/4.32/0001-Add-ARC64-support.patch
+++ b/package/libnspr/4.32/0001-Add-ARC64-support.patch
@@ -1,0 +1,89 @@
+From ffa5cee994468374e1b28328d0a4c5a4177cc02a Mon Sep 17 00:00:00 2001
+From: Veronika Kremneva <kremneva@synopsys.com>
+Date: Mon, 27 Sep 2021 15:28:12 +0300
+Subject: [PATCH] Add ARC64 support
+
+This patch adds support for ARC64 to NSPR and it is here temporarily
+until those changes will be (hopefully) incorporated.
+Bugzilla report: https://bugzilla.mozilla.org/show_bug.cgi?id=1732938
+
+Kudos to Claudiu Zissulescu for his valuable input on this topic.
+
+Signed-off-by: Veronika Kremneva <kremneba@synopsys.com>
+---
+ nspr/pr/include/md/_linux.cfg | 45 +++++++++++++++++++++++++++++++++++++++++++
+ nspr/pr/include/md/_linux.h   |  2 ++
+ 2 files changed, 47 insertions(+)
+
+diff --git a/nspr/pr/include/md/_linux.cfg b/nspr/pr/include/md/_linux.cfg
+index 23b160fde2..829735d456 100644
+--- a/nspr/pr/include/md/_linux.cfg
++++ b/nspr/pr/include/md/_linux.cfg
+@@ -1157,6 +1157,51 @@
+ #define PR_BYTES_PER_WORD_LOG2   2
+ #define PR_BYTES_PER_DWORD_LOG2  3
+ 
++#elif defined(__ARC64__)
++
++#define IS_LITTLE_ENDIAN 1
++#undef  IS_BIG_ENDIAN
++
++#define PR_BYTES_PER_BYTE   1
++#define PR_BYTES_PER_SHORT  2
++#define PR_BYTES_PER_INT    4
++#define PR_BYTES_PER_INT64  8
++#define PR_BYTES_PER_LONG   8
++#define PR_BYTES_PER_FLOAT  4
++#define PR_BYTES_PER_DOUBLE 8
++#define PR_BYTES_PER_WORD   4
++#define PR_BYTES_PER_DWORD  8
++
++#define PR_BITS_PER_BYTE    8
++#define PR_BITS_PER_SHORT   16
++#define PR_BITS_PER_INT     32
++#define PR_BITS_PER_INT64   64
++#define PR_BITS_PER_LONG    64
++#define PR_BITS_PER_FLOAT   32
++#define PR_BITS_PER_DOUBLE  64
++#define PR_BITS_PER_WORD    32
++
++#define PR_BITS_PER_BYTE_LOG2   3
++#define PR_BITS_PER_SHORT_LOG2  4
++#define PR_BITS_PER_INT_LOG2    5
++#define PR_BITS_PER_INT64_LOG2  6
++#define PR_BITS_PER_LONG_LOG2   6
++#define PR_BITS_PER_FLOAT_LOG2  5
++#define PR_BITS_PER_DOUBLE_LOG2 6
++#define PR_BITS_PER_WORD_LOG2   5
++
++#define PR_ALIGN_OF_SHORT   2
++#define PR_ALIGN_OF_INT     4
++#define PR_ALIGN_OF_LONG    8
++#define PR_ALIGN_OF_INT64   8
++#define PR_ALIGN_OF_FLOAT   4
++#define PR_ALIGN_OF_DOUBLE  8
++#define PR_ALIGN_OF_POINTER 8
++#define PR_ALIGN_OF_WORD    8
++
++#define PR_BYTES_PER_WORD_LOG2   3
++#define PR_BYTES_PER_DWORD_LOG2  3
++
+ #elif defined(__nios2__) || defined(__microblaze__) || defined(__nds32__) || \
+       defined(__xtensa__)
+ 
+diff --git a/nspr/pr/include/md/_linux.h b/nspr/pr/include/md/_linux.h
+index a26291a806..75da088e93 100644
+--- a/nspr/pr/include/md/_linux.h
++++ b/nspr/pr/include/md/_linux.h
+@@ -65,6 +65,8 @@
+ #define _PR_SI_ARCHITECTURE "e2k"
+ #elif defined(__arc__)
+ #define _PR_SI_ARCHITECTURE "arc"
++#elif defined(__ARC64__)
++#define _PR_SI_ARCHITECTURE "ARC64"
+ #elif defined(__nios2__)
+ #define _PR_SI_ARCHITECTURE "nios2"
+ #elif defined(__microblaze__)
+-- 
+2.16.2
+


### PR DESCRIPTION
When building with ARC64 for _libnspr_ getting an error:

----------------------------------------->8-------------------------------------------
In file included from ../../../dist/include/nspr/prtypes.h:26,
from ../../../dist/include/nspr/pratom.h:14,
from ../../../dist/include/nspr/nspr.h:9,
from ../../../pr/include/private/primpl.h:27,
from prfdcach.c:6:
../../../dist/include/nspr/prcpucfg.h:1260:2: error: #error "Unknown CPU architecture"
1260 | #error "Unknown CPU architecture"
| ^~~~~
----------------------------------------->8-------------------------------------------

More failures here: http://ru20arcgnu1:8080/?reason=libnspr-4.32

To add support for ARC64 Bugzilla report was filed: https://bugzilla.mozilla.org/show_bug.cgi?id=1732938

This PR adds patch for our Buildroot so we can build _libnspr_ in the meantime. 