### PR TITLE
package/gstreamer1: Add ARC64 architecture

### DIFF
--- a/package/gstreamer1/gstreamer1/1.18.4/0001-gstreamer-gst-gstconfig.h.in-Add-support-for-ARC64-a.patch
+++ b/package/gstreamer1/gstreamer1/1.18.4/0001-gstreamer-gst-gstconfig.h.in-Add-support-for-ARC64-a.patch
@@ -1,0 +1,31 @@
+From 3c14c33d6108f239c8164733280856c13ba7cc70 Mon Sep 17 00:00:00 2001
+From: Veronika Kremneva <kremneva@synopsys.com>
+Date: Fri, 8 Oct 2021 13:56:02 +0300
+Subject: [PATCH] gstreamer/gst/gstconfig.h.in: Add support for ARC64
+ architecture
+
+This patch it temporary until merge request 
+https://gitlab.freedesktop.org/vkremneva/gstreamer/-/merge_requests/1?commit_id=3c14c33d6108f239c8164733280856c13ba7cc70
+is accepted.
+
+Signed-off-by: Veronika Kremneva <kremneva@synopsys.com>
+---
+ gst/gstconfig.h.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/gstconfig.h.in b/gst/gstconfig.h.in
+index cc5794e..bde6057 100644
+--- a/gst/gstconfig.h.in
++++ b/gst/gstconfig.h.in
+@@ -124,7 +124,7 @@
+  * http://docs.oracle.com/cd/E19205-01/820-4155/c++_faq.html#Vers6
+  * https://software.intel.com/en-us/node/583402
+  */
+-#if defined(__alpha__) || defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__bfin) || defined(__hppa__) || defined(__nios2__) || defined(__MICROBLAZE__) || defined(__mips__) || defined(__or1k__) || defined(__sh__) || defined(__SH4__) || defined(__sparc__) || defined(__sparc) || defined(__ia64__) || defined(_M_ALPHA) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_IA64) || defined(__xtensa__) || defined(__e2k__) || defined(__riscv)
++#if defined(__alpha__) || defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__bfin) || defined(__hppa__) || defined(__nios2__) || defined(__MICROBLAZE__) || defined(__mips__) || defined(__or1k__) || defined(__sh__) || defined(__SH4__) || defined(__sparc__) || defined(__sparc) || defined(__ia64__) || defined(_M_ALPHA) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_IA64) || defined(__xtensa__) || defined(__e2k__) || defined(__riscv) || defined(__ARC64__) 
+ #  define GST_HAVE_UNALIGNED_ACCESS 0
+ #elif defined(__i386__) || defined(__i386) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__ppc__) || defined(__ppc64__) || defined(__powerpc__) || defined(__powerpc64__) || defined(__m68k__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+ #  define GST_HAVE_UNALIGNED_ACCESS 1
+-- 
+1.8.3.1
+


### PR DESCRIPTION
This patch adds support of ARC64 to gstreamer1.
Similar changes are submitted to https://gitlab.freedesktop.org/gstreamer/gstreamer
[Merge request at gstreamer](https://gitlab.freedesktop.org/vkremneva/gstreamer/-/merge_requests/1?commit_id=3c14c33d6108f239c8164733280856c13ba7cc70)