### PR TITLE
Add 64k pages support

### DIFF
--- a/arch/Config.in.arc
+++ b/arch/Config.in.arc
@@ -156,6 +156,10 @@ config BR2_ARC_PAGE_SIZE_16K
 	bool "16KB"
 	depends on !BR2_arc750d
 
+config BR2_ARC_PAGE_SIZE_64K
+	bool "64KB"
+	depends on BR2_arc64
+
 endchoice
 
 config BR2_ARC_PAGE_SIZE

--- a/arch/arch.mk.arc
+++ b/arch/arch.mk.arc
@@ -14,10 +14,13 @@ endif
 # Explicitly set LD's "max-page-size" instead of relying on some defaults
 ifeq ($(BR2_ARC_PAGE_SIZE_4K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=4096
+TARGET_CFLAGS += -Wl,-z,max-page-size=4096
 else ifeq ($(BR2_ARC_PAGE_SIZE_8K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=8192
+TARGET_CFLAGS += -Wl,-z,max-page-size=8192
 else ifeq ($(BR2_ARC_PAGE_SIZE_16K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=16384
+TARGET_CFLAGS += -Wl,-z,max-page-size=16384
 endif
 
 endif

--- a/arch/arch.mk.arc
+++ b/arch/arch.mk.arc
@@ -21,6 +21,9 @@ TARGET_CFLAGS += -Wl,-z,max-page-size=8192
 else ifeq ($(BR2_ARC_PAGE_SIZE_16K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=16384
 TARGET_CFLAGS += -Wl,-z,max-page-size=16384
+else ifeq ($(BR2_ARC_PAGE_SIZE_64K),y)
+ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=65536
+TARGET_CFLAGS += -Wl,-z,max-page-size=65536
 endif
 
 endif


### PR DESCRIPTION
We now have 64k pages MMU support merged in kernel.

So we have to support it in buildroot.