### PR TITLE
ARC32: switch to arc64 toolchain branches

### DIFF
--- a/arch/arch.mk.arc
+++ b/arch/arch.mk.arc
@@ -2,9 +2,7 @@ ifeq ($(BR2_arc),y)
 
 # -matomic is always required when the ARC core has the atomic extensions
 ifeq ($(BR2_ARC_ATOMIC_EXT),y)
-ifeq ($(BR2_arc64),y)
-ARCH_TOOLCHAIN_WRAPPER_OPTS = -matomic=1
-else ifeq ($(BR2_arc32),y)
+ifeq ($(BR2_arc64)$(BR2_arc32),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS = -matomic=1
 else
 ARCH_TOOLCHAIN_WRAPPER_OPTS = -matomic

--- a/package/binutils/Config.in.host
+++ b/package/binutils/Config.in.host
@@ -45,8 +45,7 @@ endchoice
 config BR2_BINUTILS_VERSION
 	string
 	default "arc-2020.09-release"	if BR2_BINUTILS_VERSION_ARC && !BR2_arc64 && !BR2_arc32
-	default "arc64"		if BR2_BINUTILS_VERSION_ARC && BR2_arc64
-	default "arc32"		if BR2_BINUTILS_VERSION_ARC && BR2_arc32
+	default "arc64"		if BR2_BINUTILS_VERSION_ARC && (BR2_arc64 || BR2_arc32)
 	default "2.32"		if BR2_BINUTILS_VERSION_2_32_X
 	default "2.35.2"	if BR2_BINUTILS_VERSION_2_35_X
 	default "2.36.1"	if BR2_BINUTILS_VERSION_2_36_X

--- a/package/binutils/binutils.mk
+++ b/package/binutils/binutils.mk
@@ -9,10 +9,8 @@
 BINUTILS_VERSION = $(call qstrip,$(BR2_BINUTILS_VERSION))
 ifeq ($(BINUTILS_VERSION),)
 ifeq ($(BR2_arc),y)
-ifeq ($(BR2_arc64),y)
+ifeq ($(BR2_arc64)$(BR2_arc32),y)
 BINUTILS_VERSION = arc64
-else ifeq ($(BR2_arc32),y)
-BINUTILS_VERSION = arc32
 else
 BINUTILS_VERSION = arc-2020.09-release
 endif
@@ -28,12 +26,6 @@ BINUTILS_FROM_GIT = y
 endif
 
 ifeq ($(BINUTILS_VERSION),arc64)
-BINUTILS_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,binutils-gdb,$(BINUTILS_VERSION))
-BINUTILS_SOURCE = binutils-gdb-$(BINUTILS_VERSION).tar.gz
-BINUTILS_FROM_GIT = y
-endif
-
-ifeq ($(BINUTILS_VERSION),arc32)
 BINUTILS_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,binutils-gdb,$(BINUTILS_VERSION))
 BINUTILS_SOURCE = binutils-gdb-$(BINUTILS_VERSION).tar.gz
 BINUTILS_FROM_GIT = y

--- a/package/gcc/Config.in.host
+++ b/package/gcc/Config.in.host
@@ -83,8 +83,7 @@ config BR2_GCC_VERSION
 	default "10.3.0"    if BR2_GCC_VERSION_10_X
 	default "11.2.0"    if BR2_GCC_VERSION_11_X
 	default "arc-2020.09-release" if BR2_GCC_VERSION_ARC && !BR2_arc64 && !BR2_arc32
-	default "arc64"     if BR2_GCC_VERSION_ARC && BR2_arc64
-	default "arc32"     if BR2_GCC_VERSION_ARC && BR2_arc32
+	default "arc64"     if BR2_GCC_VERSION_ARC && (BR2_arc64 || BR2_arc32)
 
 config BR2_EXTRA_GCC_CONFIG_OPTIONS
 	string "Additional gcc options"

--- a/package/glibc/glibc.mk
+++ b/package/glibc/glibc.mk
@@ -4,11 +4,8 @@
 #
 ################################################################################
 
-ifeq ($(BR2_arc64),y)
+ifeq ($(BR2_arc64)$(BR2_arc32),y)
 GLIBC_VERSION =  arc64
-GLIBC_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,glibc,$(GLIBC_VERSION))
-else ifeq ($(BR2_arc32),y)
-GLIBC_VERSION =  arc32
 GLIBC_SITE = $(call github,foss-for-synopsys-dwc-arc-processors,glibc,$(GLIBC_VERSION))
 else
 # Generate version string using:


### PR DESCRIPTION
Support for both ARC32 and ARC64 is now available on arc64 branches
of toolchain repositories. Switch to arc64 branches for ARC32.

Signed-off-by: Sergey Matyukevich <sergey.matyukevich@synopsys.com>