### PR TITLE
ARC: add -z max-page-size option to the TARGET_LDFLAGS

### DIFF
--- a/arch/arch.mk.arc
+++ b/arch/arch.mk.arc
@@ -13,15 +13,19 @@ endif
 ifeq ($(BR2_ARC_PAGE_SIZE_4K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=4096
 TARGET_CFLAGS += -Wl,-z,max-page-size=4096
+TARGET_LDFLAGS += -Wl,-z,max-page-size=4096
 else ifeq ($(BR2_ARC_PAGE_SIZE_8K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=8192
 TARGET_CFLAGS += -Wl,-z,max-page-size=8192
+TARGET_LDFLAGS += -Wl,-z,max-page-size=8192
 else ifeq ($(BR2_ARC_PAGE_SIZE_16K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=16384
 TARGET_CFLAGS += -Wl,-z,max-page-size=16384
+TARGET_LDFLAGS += -Wl,-z,max-page-size=16384
 else ifeq ($(BR2_ARC_PAGE_SIZE_64K),y)
 ARCH_TOOLCHAIN_WRAPPER_OPTS += -Wl,-z,max-page-size=65536
 TARGET_CFLAGS += -Wl,-z,max-page-size=65536
+TARGET_LDFLAGS += -Wl,-z,max-page-size=65536
 endif
 
 endif


### PR DESCRIPTION
Explicitly add linker option ```-z max-page-size``` to the _TARGET_LDFLAGS_. 
Fix the problem with incorrect segments alignment for some libraries(libstdc++) in systems with 16K,64K page size.


